### PR TITLE
Don't save null-value items

### DIFF
--- a/rxloader/src/main/java/me/tatarka/rxloader/ParcelableSaveCallback.java
+++ b/rxloader/src/main/java/me/tatarka/rxloader/ParcelableSaveCallback.java
@@ -12,7 +12,9 @@ import android.os.Parcelable;
 public class ParcelableSaveCallback<T> implements SaveCallback<T> {
     @Override
     public void onSave(String key, T value, Bundle outState) {
-        outState.putParcelable(key, (Parcelable) value);
+        if (value != null) {
+            outState.putParcelable(key, (Parcelable) value);
+        }
     }
 
     @Override


### PR DESCRIPTION
Saving null-value item makes loader's callback trigger onNext with null as argument. So If you just do nothing, but went out of activity, it was killed, you come back and oops, your onNext was triggered just like it had result, but it doesn't.
E.g.
```java
@Override protected void onLoad(Bundle savedInstanceState) {
            RxLoaderManager loaderManager = RxLoaderManager.get(activityHolder.getActivity());
            loginLoader = loaderManager.create((LoginParams params) -> {
                        return sessionManager.login(params);
                    },
                    new RxLoaderObserver<Session>() {
                        @Override public void onNext(Session value) {
                            Flow.get(getView()).replaceTo(new HomeScreen());
                        }
                    }
            ).save();
        }
```